### PR TITLE
Feat: adds the savings group contract file

### DIFF
--- a/lockstarr-contract/Clarinet.toml
+++ b/lockstarr-contract/Clarinet.toml
@@ -19,6 +19,11 @@ epoch = 3.0
 path = 'contracts/fund-management.clar'
 clarity_version = 3
 epoch = 3.0
+
+[contracts.savings-group]
+path = 'contracts/savings-group.clar'
+clarity_version = 3
+epoch = 3.0
 [repl.analysis]
 passes = ['check_checker']
 

--- a/lockstarr-contract/contracts/savings-group.clar
+++ b/lockstarr-contract/contracts/savings-group.clar
@@ -1,0 +1,215 @@
+
+;; title: savings-group
+;; version:
+;; summary:
+;; description:
+
+
+;; title: savings-group
+;; version:
+;; summary:
+;; description:
+
+;; Savings Groups Smart Contract
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-not-authorized (err u100))
+(define-constant err-group-not-found (err u101))
+(define-constant err-already-member (err u102))
+(define-constant err-not-member (err u103))
+(define-constant err-insufficient-funds (err u104))
+(define-constant err-invalid-amount (err u105))
+(define-constant err-vote-exists (err u106))
+(define-constant err-no-active-proposal (err u107))
+(define-constant err-proposal-expired (err u108))
+
+;; Data Maps
+(define-map savings-groups
+  { group-id: uint }
+  {
+    name: (string-ascii 50),
+    total-funds: uint,
+    member-count: uint,
+    active-proposal: (optional {
+      proposer: principal,
+      amount: uint,
+      description: (string-ascii 100),
+      votes-for: uint,
+      votes-against: uint,
+      expiration: uint
+    })
+  }
+)
+
+(define-map group-members
+  { group-id: uint, member: principal }
+  { joined-at: uint, contribution: uint }
+)
+
+(define-map member-votes
+  { group-id: uint, member: principal }
+  { voted: bool, vote: bool }
+)
+
+;; Variables
+(define-data-var group-nonce uint u0)
+
+;; Functions
+
+;; Create a new savings group
+(define-public (create-group (name (string-ascii 50)))
+  (let
+    (
+      (new-group-id (+ (var-get group-nonce) u1))
+    )
+    (map-set savings-groups
+      { group-id: new-group-id }
+      {
+        name: name,
+        total-funds: u0,
+        member-count: u1,
+        active-proposal: none
+      }
+    )
+    (map-set group-members
+      { group-id: new-group-id, member: tx-sender }
+      { joined-at: block-height, contribution: u0 }
+    )
+    (var-set group-nonce new-group-id)
+    (ok new-group-id)
+  )
+)
+
+;; Join an existing savings group
+(define-public (join-group (group-id uint))
+  (let
+    (
+      (group (unwrap! (map-get? savings-groups { group-id: group-id }) err-group-not-found))
+    )
+    (asserts! (is-none (map-get? group-members { group-id: group-id, member: tx-sender })) err-already-member)
+    (map-set group-members
+      { group-id: group-id, member: tx-sender }
+      { joined-at: block-height, contribution: u0 }
+    )
+    (map-set savings-groups
+      { group-id: group-id }
+      (merge group { member-count: (+ (get member-count group) u1) })
+    )
+    (ok true)
+  )
+)
+
+;; Contribute to the group's fund
+(define-public (contribute (group-id uint) (amount uint))
+  (let
+    (
+      (group (unwrap! (map-get? savings-groups { group-id: group-id }) err-group-not-found))
+      (member (unwrap! (map-get? group-members { group-id: group-id, member: tx-sender }) err-not-member))
+    )
+    (asserts! (> amount u0) err-invalid-amount)
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (map-set savings-groups
+      { group-id: group-id }
+      (merge group { total-funds: (+ (get total-funds group) amount) })
+    )
+    (map-set group-members
+      { group-id: group-id, member: tx-sender }
+      (merge member { contribution: (+ (get contribution member) amount) })
+    )
+    (ok true)
+  )
+)
+
+;; Create a proposal for fund withdrawal
+(define-public (create-proposal (group-id uint) (amount uint) (description (string-ascii 100)))
+  (let
+    (
+      (group (unwrap! (map-get? savings-groups { group-id: group-id }) err-group-not-found))
+    )
+    (asserts! (is-some (map-get? group-members { group-id: group-id, member: tx-sender })) err-not-member)
+    (asserts! (is-none (get active-proposal group)) err-vote-exists)
+    (asserts! (<= amount (get total-funds group)) err-insufficient-funds)
+    (map-set savings-groups
+      { group-id: group-id }
+      (merge group {
+        active-proposal: (some {
+          proposer: tx-sender,
+          amount: amount,
+          description: description,
+          votes-for: u0,
+          votes-against: u0,
+          expiration: (+ block-height u144)  ;; Set expiration to 24 hours (assuming 10-minute block times)
+        })
+      })
+    )
+    (ok true)
+  )
+)
+
+;; Vote on an active proposal
+(define-public (vote-on-proposal (group-id uint) (vote bool))
+  (let
+    (
+      (group (unwrap! (map-get? savings-groups { group-id: group-id }) err-group-not-found))
+      (proposal (unwrap! (get active-proposal group) err-no-active-proposal))
+      (member-vote (default-to { voted: false, vote: false } (map-get? member-votes { group-id: group-id, member: tx-sender })))
+    )
+    (asserts! (is-some (map-get? group-members { group-id: group-id, member: tx-sender })) err-not-member)
+    (asserts! (< block-height (get expiration proposal)) err-proposal-expired)
+    (asserts! (not (get voted member-vote)) err-vote-exists)
+    (map-set member-votes
+      { group-id: group-id, member: tx-sender }
+      { voted: true, vote: vote }
+    )
+    (map-set savings-groups
+      { group-id: group-id }
+      (merge group {
+        active-proposal: (some (merge proposal {
+          votes-for: (if vote (+ (get votes-for proposal) u1) (get votes-for proposal)),
+          votes-against: (if (not vote) (+ (get votes-against proposal) u1) (get votes-against proposal))
+        }))
+      })
+    )
+    (ok true)
+  )
+)
+
+;; Execute the proposal if it passes
+(define-public (execute-proposal (group-id uint))
+  (let
+    (
+      (group (unwrap! (map-get? savings-groups { group-id: group-id }) err-group-not-found))
+      (proposal (unwrap! (get active-proposal group) err-no-active-proposal))
+    )
+    (asserts! (>= block-height (get expiration proposal)) err-proposal-expired)
+    (asserts! (> (get votes-for proposal) (get votes-against proposal)) err-insufficient-funds)
+    (try! (as-contract (stx-transfer? (get amount proposal) tx-sender (get proposer proposal))))
+    (map-set savings-groups
+      { group-id: group-id }
+      (merge group {
+        total-funds: (- (get total-funds group) (get amount proposal)),
+        active-proposal: none
+      })
+    )
+    (ok true)
+  )
+)
+
+;; Read-only functions
+
+;; Get group details
+(define-read-only (get-group (group-id uint))
+  (map-get? savings-groups { group-id: group-id })
+)
+
+;; Get member details
+(define-read-only (get-member (group-id uint) (member principal))
+  (map-get? group-members { group-id: group-id, member: member })
+)
+
+;; Get member's vote
+(define-read-only (get-member-vote (group-id uint) (member principal))
+  (map-get? member-votes { group-id: group-id, member: member })
+)
+

--- a/lockstarr-contract/contracts/savings-group.clar
+++ b/lockstarr-contract/contracts/savings-group.clar
@@ -100,6 +100,7 @@
   )
 )
 
+
 ;; Contribute to the group's fund
 (define-public (contribute (group-id uint) (amount uint))
   (let
@@ -212,4 +213,3 @@
 (define-read-only (get-member-vote (group-id uint) (member principal))
   (map-get? member-votes { group-id: group-id, member: member })
 )
-

--- a/lockstarr-contract/tests/savings-group.test.ts
+++ b/lockstarr-contract/tests/savings-group.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Savings Group Smart Contract

This smart contract allows for the creation and management of savings groups. These groups can be used for pooling funds among members, creating proposals for fund withdrawals, and voting on whether to approve those proposals. The contract ensures transparency and accountability in managing pooled funds, with various checks and balances in place to ensure that funds are handled properly.

## Features

1. **Group Creation**: Users can create a new savings group with a name and initial member (the creator).
2. **Joining Groups**: Members can join an existing savings group.
3. **Fund Contributions**: Members can contribute to the group’s pooled funds.
4. **Proposal Creation**: Members can propose fund withdrawals, including an amount and a description of the intended use of the funds.
5. **Voting on Proposals**: Group members can vote on proposals to approve or reject fund withdrawals.
6. **Proposal Execution**: If a proposal is approved by the majority, the requested funds are transferred to the proposer.
7. **Transparency**: All transactions, member details, votes, and proposals are accessible to any user.

## Key Functions

### 1. `create-group`
- **Input**:
  - `name`: The name of the savings group (string of up to 50 characters).
- **Output**:
  - A unique group ID for the newly created group.
- **Description**:
  - Creates a new savings group with the specified name. The creator of the group is automatically added as a member with zero contribution.

### 2. `join-group`
- **Input**:
  - `group-id`: The ID of the group to join.
- **Output**:
  - A boolean indicating whether the operation was successful.
- **Description**:
  - Allows a user to join an existing savings group. The user must not already be a member of the group.

### 3. `contribute`
- **Input**:
  - `group-id`: The ID of the group to which the member is contributing.
  - `amount`: The amount to contribute (in STX).
- **Output**:
  - A boolean indicating whether the contribution was successful.
- **Description**:
  - Allows a member to contribute a specified amount to the group's pooled funds. The contract ensures that the contribution amount is valid and the transfer is successful.

### 4. `create-proposal`
- **Input**:
  - `group-id`: The ID of the group for which the proposal is being created.
  - `amount`: The amount of funds to be withdrawn.
  - `description`: A description of the proposal (string of up to 100 characters).
- **Output**:
  - A boolean indicating whether the proposal was successfully created.
- **Description**:
  - A member can propose a withdrawal of funds from the group for a specific purpose. The proposal will include the requested amount and a description. The contract ensures that no active proposal already exists and that the requested amount does not exceed the group's total funds.

### 5. `vote-on-proposal`
- **Input**:
  - `group-id`: The ID of the group for which the vote is being cast.
  - `vote`: A boolean indicating the member's vote (true for "approve", false for "reject").
- **Output**:
  - A boolean indicating whether the vote was successfully cast.
- **Description**:
  - Allows group members to vote on an active proposal. The contract ensures that members cannot vote multiple times on the same proposal, and the proposal must still be active.

### 6. `execute-proposal`
- **Input**:
  - `group-id`: The ID of the group with the active proposal.
- **Output**:
  - A boolean indicating whether the proposal was successfully executed.
- **Description**:
  - Executes the approved proposal if it passes the vote. The funds are transferred to the proposer, and the group's total funds are updated accordingly. Only proposals with more "for" votes than "against" votes are executed.

### 7. `get-group`
- **Input**:
  - `group-id`: The ID of the group.
- **Output**:
  - The details of the group, including the name, total funds, member count, and the active proposal (if any).
- **Description**:
  - This read-only function allows anyone to retrieve the details of a specific savings group.

### 8. `get-member`
- **Input**:
  - `group-id`: The ID of the group.
  - `member`: The principal (address) of the member.
- **Output**:
  - The details of the specified member, including their join date and contribution amount.
- **Description**:
  - This read-only function allows anyone to retrieve the details of a specific member within a group.

### 9. `get-member-vote`
- **Input**:
  - `group-id`: The ID of the group.
  - `member`: The principal (address) of the member.
- **Output**:
  - The vote cast by the specified member (whether they voted for or against the active proposal).
- **Description**:
  - This read-only function allows anyone to retrieve the vote cast by a member on the active proposal within the group.

## Constants & Error Codes

- **Constants**:
  - `contract-owner`: The principal of the contract owner (usually set to the deployer's principal).
  - `tx-sender`: The sender of the transaction (the address executing the function).

- **Error Codes**:
  - `err-not-authorized`: Error when the sender is not authorized to perform an action.
  - `err-group-not-found`: Error when the specified group does not exist.
  - `err-already-member`: Error when the sender is already a member of the group.
  - `err-not-member`: Error when the sender is not a member of the group.
  - `err-insufficient-funds`: Error when the group does not have enough funds for a requested proposal.
  - `err-invalid-amount`: Error when the specified contribution amount is invalid (non-positive).
  - `err-vote-exists`: Error when the sender has already voted on the proposal.
  - `err-no-active-proposal`: Error when no active proposal exists for the group.
  - `err-proposal-expired`: Error when the proposal has expired and can no longer be voted on or executed.

## Data Structures

- **Savings Groups**:
  - `group-id`: Unique identifier for each savings group.
  - `name`: The name of the group.
  - `total-funds`: The total amount of funds in the group's pool.
  - `member-count`: The number of members in the group.
  - `active-proposal`: An optional active proposal for fund withdrawal (if any).

- **Group Members**:
  - `group-id`: The ID of the group to which the member belongs.
  - `member`: The principal address of the member.
  - `joined-at`: The block height at which the member joined the group.
  - `contribution`: The amount contributed by the member to the group's pool.

- **Member Votes**:
  - `group-id`: The ID of the group in which the vote is cast.
  - `member`: The principal address of the member casting the vote.
  - `voted`: A boolean indicating whether the member has voted.
  - `vote`: A boolean indicating the member's vote (true for "approve", false for "reject").

## Initialization

- **Group Nonce**:
  - The group nonce keeps track of the number of groups created and ensures that each new group has a unique ID. The counter starts at 0 and is incremented with each new group creation.

## Deployment

This contract can be deployed to the Stacks blockchain, allowing users to create and manage savings groups. Members can contribute, propose fund withdrawals, and vote on proposals, ensuring that all decisions are made collectively and transparently.

---

## Example Usage

### 1. Create a Group
```clojure
(create-group "Neighborhood Savings")
```
This creates a new group called "Neighborhood Savings" and adds the caller as the first member.

### 2. Join a Group
```clojure
(join-group 1)
```
This adds the caller as a member of the group with ID 1.

### 3. Contribute to a Group
```clojure
(contribute 1 100)
```
This allows the caller to contribute 100 STX to the group with ID 1.

### 4. Create a Proposal
```clojure
(create-proposal 1 200 "Fund neighborhood event")
```
This creates a proposal for withdrawing 200 STX from the group's funds to fund a neighborhood event.

### 5. Vote on a Proposal
```clojure
(vote-on-proposal 1 true)
```
This allows the caller to vote in favor of the active proposal in group 1.

### 6. Execute a Proposal
```clojure
(execute-proposal 1)
```
This executes the proposal if it has passed, transferring the funds to the proposer.

### 7. Get Group Details
```clojure
(get-group 1)
```
This retrieves the details of the group with ID 1.

### 8. Get Member Details
```clojure
(get-member 1 "SP2BG...")
```
This retrieves the details of the member with the principal "SP2BG..." in group 1.

### 9. Get Member Vote
```clojure
(get-member-vote 1 "SP2BG...")
```
This retrieves the vote cast by the member with the principal "SP2BG..." in group 1.

## License

This contract is open source and available for modification and redistribution under the [[MIT License](https://chatgpt.com/LICENSE)](LICENSE).